### PR TITLE
fix: remove usage of _init() with parameters

### DIFF
--- a/addons/silicon.vfx.tilebreaker/spatial_tile_breaker.gd
+++ b/addons/silicon.vfx.tilebreaker/spatial_tile_breaker.gd
@@ -142,7 +142,7 @@ func _init() -> void:
 	dirty_shader = true
 	
 	yield(VisualServer, "frame_post_draw")
-	preload("tile_breaker_cleanup.gd").new(self)
+	preload("tile_breaker_cleanup.gd").new().clean(self)
 
 func _update() -> void:
 	if tile_breaker_quality != ProjectSettings.get_setting("rendering/quality/tile_breaker/quality"):

--- a/addons/silicon.vfx.tilebreaker/tile_breaker_cleanup.gd
+++ b/addons/silicon.vfx.tilebreaker/tile_breaker_cleanup.gd
@@ -5,7 +5,7 @@ extends Reference
 var adjusted_shader := [] # RID inside
 var material: Material
 
-func _init(material: Material) -> void:
+func clean(material: Material) -> void:
 	self.material = material
 	self.adjusted_shader.append(material.adjusted_shader)
 	if material.has_meta("_tile_breaker_cleanup"):


### PR DESCRIPTION
Godot is not fond of parameters in `_init()`, and will raise errors.

We could also use a static factory. (but there would be an extra `load()`)